### PR TITLE
fix: typo in imgpkg url

### DIFF
--- a/installer/internal/algo/ubuntu22_04_k8s.go
+++ b/installer/internal/algo/ubuntu22_04_k8s.go
@@ -90,7 +90,7 @@ if ! command -v imgpkg >>/dev/null; then
 fi
 
 echo "downloading bundle"
-mkdir -p $c
+mkdir -p $BUNDLE_PATH
 imgpkg pull -i $BUNDLE_ADDR-scripts -o $BUNDLE_PATH`
 
 	DoUbuntuK8S = `


### PR DESCRIPTION
Fixed typo

Caused by f72bb0ff38ec9a8d19a9e574d763936b1186e9e9