### PR TITLE
chore(deps): upgrade kube-vip to v0.8.0

### DIFF
--- a/docs/cluster_class.md
+++ b/docs/cluster_class.md
@@ -162,7 +162,7 @@ spec:
                 value: "10"
               - name: vip_retryperiod
                 value: "2"
-              image: ghcr.io/kube-vip/kube-vip:v0.5.0
+              image: ghcr.io/kube-vip/kube-vip:v0.8.0
               imagePullPolicy: IfNotPresent
               name: kube-vip
               resources: {}

--- a/test/e2e/data/infrastructure-provider-byoh/v1beta1/templates/docker/cluster-template-topology-docker.yaml
+++ b/test/e2e/data/infrastructure-provider-byoh/v1beta1/templates/docker/cluster-template-topology-docker.yaml
@@ -52,7 +52,7 @@ spec:
                 value: "10"
               - name: vip_retryperiod
                 value: "2"
-              image: ghcr.io/kube-vip/kube-vip:v0.5.0
+              image: ghcr.io/kube-vip/kube-vip:v0.8.0
               imagePullPolicy: IfNotPresent
               name: kube-vip
               resources: {}

--- a/test/e2e/data/infrastructure-provider-byoh/v1beta1/templates/docker/cluster-template.yaml
+++ b/test/e2e/data/infrastructure-provider-byoh/v1beta1/templates/docker/cluster-template.yaml
@@ -106,7 +106,7 @@ spec:
               value: "10"
             - name: vip_retryperiod
               value: "2"
-            image: ghcr.io/kube-vip/kube-vip:v0.5.0
+            image: ghcr.io/kube-vip/kube-vip:v0.8.0
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}

--- a/test/e2e/data/infrastructure-provider-byoh/v1beta1/templates/docker/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-provider-byoh/v1beta1/templates/docker/cluster-with-kcp.yaml
@@ -91,7 +91,7 @@ spec:
               value: "10"
             - name: vip_retryperiod
               value: "2"
-            image: ghcr.io/kube-vip/kube-vip:v0.5.0
+            image: ghcr.io/kube-vip/kube-vip:v0.8.0
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}

--- a/test/e2e/data/infrastructure-provider-byoh/v1beta1/templates/e2e/cluster-template-topology.yaml
+++ b/test/e2e/data/infrastructure-provider-byoh/v1beta1/templates/e2e/cluster-template-topology.yaml
@@ -56,7 +56,7 @@ spec:
                 value: "10"
               - name: vip_retryperiod
                 value: "2"
-              image: ghcr.io/kube-vip/kube-vip:v0.5.0
+              image: ghcr.io/kube-vip/kube-vip:v0.8.0
               imagePullPolicy: IfNotPresent
               name: kube-vip
               resources: {}

--- a/test/e2e/data/infrastructure-provider-byoh/v1beta1/templates/e2e/cluster-template.yaml
+++ b/test/e2e/data/infrastructure-provider-byoh/v1beta1/templates/e2e/cluster-template.yaml
@@ -129,7 +129,7 @@ spec:
               value: "10"
             - name: vip_retryperiod
               value: "2"
-            image: ghcr.io/kube-vip/kube-vip:v0.5.0
+            image: ghcr.io/kube-vip/kube-vip:v0.8.0
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}

--- a/test/e2e/data/infrastructure-provider-byoh/v1beta1/templates/e2e/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-provider-byoh/v1beta1/templates/e2e/cluster-with-kcp.yaml
@@ -94,7 +94,7 @@ spec:
               value: "10"
             - name: vip_retryperiod
               value: "2"
-            image: ghcr.io/kube-vip/kube-vip:v0.5.0
+            image: ghcr.io/kube-vip/kube-vip:v0.8.0
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}

--- a/test/e2e/data/infrastructure-provider-byoh/v1beta1/templates/vm/cluster-template-topology.yaml
+++ b/test/e2e/data/infrastructure-provider-byoh/v1beta1/templates/vm/cluster-template-topology.yaml
@@ -56,7 +56,7 @@ spec:
                 value: "10"
               - name: vip_retryperiod
                 value: "2"
-              image: ghcr.io/kube-vip/kube-vip:v0.5.0
+              image: ghcr.io/kube-vip/kube-vip:v0.8.0
               imagePullPolicy: IfNotPresent
               name: kube-vip
               resources: {}

--- a/test/e2e/data/infrastructure-provider-byoh/v1beta1/templates/vm/cluster-template.yaml
+++ b/test/e2e/data/infrastructure-provider-byoh/v1beta1/templates/vm/cluster-template.yaml
@@ -104,7 +104,7 @@ spec:
               value: "10"
             - name: vip_retryperiod
               value: "2"
-            image: ghcr.io/kube-vip/kube-vip:v0.5.0
+            image: ghcr.io/kube-vip/kube-vip:v0.8.0
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}

--- a/test/e2e/data/infrastructure-provider-byoh/v1beta1/templates/vm/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-provider-byoh/v1beta1/templates/vm/cluster-with-kcp.yaml
@@ -94,7 +94,7 @@ spec:
               value: "10"
             - name: vip_retryperiod
               value: "2"
-            image: ghcr.io/kube-vip/kube-vip:v0.5.0
+            image: ghcr.io/kube-vip/kube-vip:v0.8.0
             imagePullPolicy: IfNotPresent
             name: kube-vip
             resources: {}


### PR DESCRIPTION
**What this PR does / why we need it**:

Upgraded kube-vip to latest version [0.8.0](https://github.com/kube-vip/kube-vip/releases/tag/v0.8.0)

